### PR TITLE
Support recursive import of model definition directories

### DIFF
--- a/src/java/cern/accsoft/steering/jmad/modeldefs/io/impl/JMadModelDefinitionImporterImpl.java
+++ b/src/java/cern/accsoft/steering/jmad/modeldefs/io/impl/JMadModelDefinitionImporterImpl.java
@@ -25,7 +25,15 @@
  */
 package cern.accsoft.steering.jmad.modeldefs.io.impl;
 
-import static cern.accsoft.steering.jmad.util.PathUtil.parentPath;
+import cern.accsoft.steering.jmad.modeldefs.domain.JMadModelDefinition;
+import cern.accsoft.steering.jmad.modeldefs.domain.JMadModelDefinitionImpl;
+import cern.accsoft.steering.jmad.modeldefs.domain.SourceInformation.SourceType;
+import cern.accsoft.steering.jmad.modeldefs.domain.SourceInformationImpl;
+import cern.accsoft.steering.jmad.modeldefs.io.JMadModelDefinitionImporter;
+import cern.accsoft.steering.jmad.modeldefs.io.ModelDefinitionPersistenceService;
+import cern.accsoft.steering.jmad.util.xml.PersistenceServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,16 +45,7 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import cern.accsoft.steering.jmad.modeldefs.domain.JMadModelDefinition;
-import cern.accsoft.steering.jmad.modeldefs.domain.JMadModelDefinitionImpl;
-import cern.accsoft.steering.jmad.modeldefs.domain.SourceInformation.SourceType;
-import cern.accsoft.steering.jmad.modeldefs.domain.SourceInformationImpl;
-import cern.accsoft.steering.jmad.modeldefs.io.JMadModelDefinitionImporter;
-import cern.accsoft.steering.jmad.modeldefs.io.ModelDefinitionPersistenceService;
-import cern.accsoft.steering.jmad.util.xml.PersistenceServiceException;
+import static cern.accsoft.steering.jmad.util.PathUtil.parentPath;
 
 /**
  * The default implementation of a {@link JMadModelDefinitionImporter}
@@ -100,6 +99,8 @@ public class JMadModelDefinitionImporterImpl implements JMadModelDefinitionImpor
         for (File file : fileList) {
             if (ModelDefinitionUtil.isXmlFileName(file.getName())) {
                 definitions.addAll(importFromXml(file));
+            } else if (file.isDirectory()) {
+                definitions.addAll(importFromDir(file));
             }
         }
         return definitions;


### PR DESCRIPTION
This change enables ``importModelDefinition()`` to work recursively on directories, searching for valid XML files in any subdirectories.
This is the same behavior as for importing ZIP files, where XML files are discovered no matter of their relative path in the archive. The idea is that this allows handling directory and ZIP imports in the same way.