### PR TITLE
customizable path prefixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 sudo: false
 jdk:
   - oraclejdk8

--- a/src/java/cern/accsoft/steering/jmad/domain/file/ModelFile.java
+++ b/src/java/cern/accsoft/steering/jmad/domain/file/ModelFile.java
@@ -21,62 +21,69 @@
 // @formatter:on
 
 /**
- * 
+ *
  */
 package cern.accsoft.steering.jmad.domain.file;
 
 import cern.accsoft.steering.jmad.modeldefs.io.ModelFileFinder;
 
+import java.util.Optional;
+
 /**
  * This interface represents the description of a file used for a model and provides the information where to find it.
- * 
+ *
  * @author Kajetan Fuchsberger (kajetan.fuchsberger at cern.ch)
  */
 public interface ModelFile {
 
+
     /**
      * Where to search the file? In the repository (or if not found there in the repo-copy within the jar) or in the
      * sourcepath
-     * 
+     *
      * @author Kajetan Fuchsberger (kajetan.fuchsberger at cern.ch)
      */
-    public static enum ModelFileLocation {
-        REPOSITORY("repdata") {
+    enum ModelFileLocation {
+        REPOSITORY {
             @Override
             public String getPathOffset(ModelPathOffsets offsets) {
                 return offsets.getRepositoryOffset();
             }
+
+            @Override
+            public String getResourcePrefix(ModelPathOffsets offsets) {
+                return Optional.ofNullable(offsets.getRepositoryPrefix()).orElse(DEFAULT_REPOSITORY_PREFIX);
+            }
         },
-        RESOURCE("resdata") {
+        RESOURCE {
             @Override
             public String getPathOffset(ModelPathOffsets offsets) {
                 return offsets.getResourceOffset();
             }
+
+            @Override
+            public String getResourcePrefix(ModelPathOffsets offsets) {
+                return Optional.ofNullable(offsets.getResourcePrefix()).orElse(DEFAULT_RESOURCE_PREFIX);
+            }
         };
 
-        /** The path prefix within the jar/zip/source */
-        private String resourcePrefix;
+        private static final String DEFAULT_REPOSITORY_PREFIX = "repdata";
+        private static final String DEFAULT_RESOURCE_PREFIX = "resdata";
 
         public abstract String getPathOffset(ModelPathOffsets offsets);
 
-        private ModelFileLocation(String resourcePrefix) {
-            this.resourcePrefix = resourcePrefix;
-        }
-
-        public String getResourcePrefix() {
-            return resourcePrefix;
-        }
+        public abstract String getResourcePrefix(ModelPathOffsets offsets);
     }
-   
-    
+
+
     /**
      * @return the name used by the {@link ModelFileFinder} to find the file.
      */
-    public abstract String getName();
+    String getName();
 
     /**
      * @return the location where to search for the file.
      */
-    public abstract ModelFileLocation getLocation();
+    ModelFileLocation getLocation();
 
 }

--- a/src/java/cern/accsoft/steering/jmad/domain/file/ModelPathOffsets.java
+++ b/src/java/cern/accsoft/steering/jmad/domain/file/ModelPathOffsets.java
@@ -37,13 +37,27 @@ public interface ModelPathOffsets {
      * 
      * @return the offset
      */
-    public abstract String getResourceOffset();
+    String getResourceOffset();
 
     /**
      * this method must return the offset within the repository.
      * 
      * @return the offset
      */
-    public abstract String getRepositoryOffset();
+    String getRepositoryOffset();
+
+    /**
+     * this method must return the prefix of the resource-path-tree.
+     *
+     * @return the prefix
+     */
+    String getResourcePrefix();
+
+    /**
+     * this method must return the prefix of the repository path tree.
+     *
+     * @return the offset
+     */
+    String getRepositoryPrefix();
 
 }

--- a/src/java/cern/accsoft/steering/jmad/domain/file/ModelPathOffsetsImpl.java
+++ b/src/java/cern/accsoft/steering/jmad/domain/file/ModelPathOffsetsImpl.java
@@ -21,7 +21,7 @@
 // @formatter:on
 
 /**
- * 
+ *
  */
 package cern.accsoft.steering.jmad.domain.file;
 
@@ -39,6 +39,12 @@ public class ModelPathOffsetsImpl implements ModelPathOffsets {
     @XStreamAlias("resource-offset")
     private String resourceOffset = null;
 
+    @XStreamAlias("repository-prefix")
+    private String repositoryPrefix = null;
+
+    @XStreamAlias("resource-prefix")
+    private String resourcePrefix = null;
+
     @Override
     public String getRepositoryOffset() {
         return this.repositoryOffset;
@@ -49,6 +55,16 @@ public class ModelPathOffsetsImpl implements ModelPathOffsets {
         return this.resourceOffset;
     }
 
+    @Override
+    public String getRepositoryPrefix() {
+        return this.repositoryPrefix;
+    }
+
+    @Override
+    public String getResourcePrefix() {
+        return this.resourcePrefix;
+    }
+
     public void setResourceOffset(String resourceOffset) {
         this.resourceOffset = resourceOffset;
     }
@@ -57,4 +73,11 @@ public class ModelPathOffsetsImpl implements ModelPathOffsets {
         this.repositoryOffset = repositoryOffset;
     }
 
+    public void setResourcePrefix(String resourcePrefix) {
+        this.resourcePrefix = resourcePrefix;
+    }
+
+    public void setRepositoryPrefix(String repositoryPrefix) {
+        this.repositoryPrefix = repositoryPrefix;
+    }
 }

--- a/src/java/cern/accsoft/steering/jmad/modeldefs/io/impl/ModelFileFinderImpl.java
+++ b/src/java/cern/accsoft/steering/jmad/modeldefs/io/impl/ModelFileFinderImpl.java
@@ -257,8 +257,8 @@ public class ModelFileFinderImpl implements ModelFileFinder {
         String resourcePath = modelFile.getName();
         /* 2) the model definition - dependent offset */
         resourcePath = prependPathOffset(resourcePath, modelFile.getLocation().getPathOffset(this.modelPathOffsets));
-        /* 3) the offset depending on the type (Resource or repo file) */
-        resourcePath = prependPathOffset(resourcePath, modelFile.getLocation().getResourcePrefix());
+        /* 3) the offset depending on the type (Resource or repo file; can be overridden by the model definition) */
+        resourcePath = prependPathOffset(resourcePath, modelFile.getLocation().getResourcePrefix(this.modelPathOffsets));
 
         return resourcePath;
     }


### PR DESCRIPTION
 Extend path-offset functionality to make the prefixes for repository (repdata) and resource data (resdata) overridable.

Introduced XML elements: repository-prefix and resource-prefix (under path-offsets).
This enables a more flexible layout of JMad models, e.g. in shared repositories.

Example usage:
```xml
  <path-offsets>
    <repository-prefix value="." />
    <resource-prefix value="jmad-scripts" />
  </path-offsets>
```