### PR TITLE
canonicalize file names in ZIP and JAR archives

### DIFF
--- a/src/java/cern/accsoft/steering/jmad/modeldefs/io/impl/ModelFileFinderImpl.java
+++ b/src/java/cern/accsoft/steering/jmad/modeldefs/io/impl/ModelFileFinderImpl.java
@@ -25,22 +25,6 @@
  */
 package cern.accsoft.steering.jmad.modeldefs.io.impl;
 
-import static cern.accsoft.steering.jmad.util.ResourceUtil.prependPathOffset;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import cern.accsoft.steering.jmad.domain.file.ModelFile;
 import cern.accsoft.steering.jmad.domain.file.ModelFile.ModelFileLocation;
 import cern.accsoft.steering.jmad.domain.file.ModelPathOffsets;
@@ -52,6 +36,21 @@ import cern.accsoft.steering.jmad.modeldefs.io.ModelFileFinder;
 import cern.accsoft.steering.jmad.util.JMadPreferences;
 import cern.accsoft.steering.jmad.util.StreamUtil;
 import cern.accsoft.steering.jmad.util.TempFileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static cern.accsoft.steering.jmad.util.ResourceUtil.canonicalizePath;
+import static cern.accsoft.steering.jmad.util.ResourceUtil.prependPathOffset;
 
 /**
  * This is the implementation of a class that finds model-files.
@@ -133,11 +132,11 @@ public class ModelFileFinderImpl implements ModelFileFinder {
         String archivePath = getArchivePath(modelFile);
         if (SourceType.JAR == sourceType) {
             String path = prependPathOffset(archivePath, ModelDefinitionUtil.PACKAGE_OFFSET);
-            return ModelDefinitionUtil.BASE_CLASS.getResourceAsStream(path);
+            return ModelDefinitionUtil.BASE_CLASS.getResourceAsStream(canonicalizePath(path));
         } else if (SourceType.ZIP == sourceType) {
             /* 4) if there is an offset with in the archive, then also prepend this one */
             String withinZipPath = prependPathOffset(archivePath, sourceInformation.getPathOffsetWithinArchive());
-            return getZipInputStream(getSourceInformation().getRootPath(), withinZipPath);
+            return getZipInputStream(getSourceInformation().getRootPath(), canonicalizePath(withinZipPath));
         } else if (SourceType.FILE == sourceType) {
             return getFileInputStream(getSourceInformation().getRootPath(), archivePath);
         } else {
@@ -176,9 +175,6 @@ public class ModelFileFinderImpl implements ModelFileFinder {
         ZipFile zipFile;
         try {
             zipFile = new ZipFile(file);
-        } catch (ZipException e) {
-            LOGGER.error("Could not open zip file '" + file.getAbsolutePath() + "'");
-            return null;
         } catch (IOException e) {
             LOGGER.error("Could not open zip file '" + file.getAbsolutePath() + "'");
             return null;

--- a/src/java/cern/accsoft/steering/jmad/util/ResourceUtil.java
+++ b/src/java/cern/accsoft/steering/jmad/util/ResourceUtil.java
@@ -22,17 +22,21 @@
 
 /*
  * $Id: ResourceUtil.java,v 1.5 2009-02-25 18:48:27 kfuchsbe Exp $
- * 
+ *
  * $Date: 2009-02-25 18:48:27 $ $Revision: 1.5 $ $Author: kfuchsbe $
- * 
+ *
  * Copyright CERN, All Rights Reserved.
  */
 package cern.accsoft.steering.jmad.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -40,16 +44,15 @@ import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * This class provides methods to handle resource files
- * 
+ *
  * @author Kajetan Fuchsberger (kajetan.fuchsberger at cern.ch)
  */
 public final class ResourceUtil {
-    /** the logger for the class */
+    /**
+     * the logger for the class
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUtil.class);
 
     private ResourceUtil() {
@@ -58,7 +61,7 @@ public final class ResourceUtil {
 
     /**
      * searches all the resources in the classpath to get a list of all the resources in the given package.
-     * 
+     *
      * @param packageName the package name in which to search for the resources.
      * @return the names of the resources (without leading package names)
      */
@@ -77,9 +80,9 @@ public final class ResourceUtil {
 
     /**
      * just adds a prefix to the path
-     * 
+     *
      * @param filepath the path to which to add the prefix
-     * @param offset the offset to add as prefix
+     * @param offset   the offset to add as prefix
      * @return the whole path
      */
     public static String prependPathOffset(String filepath, String offset) {
@@ -94,9 +97,19 @@ public final class ResourceUtil {
     }
 
     /**
+     * Canonicalize a resource-path name by resolving "./" and "../", and replacing backslashes with slashes.
+     *
+     * @param path the path
+     * @return a canonical representation of the path
+     */
+    public static String canonicalizePath(String path) {
+        return Paths.get(path).normalize().toString().replace("\\", "/");
+    }
+
+    /**
      * Converts the given package name into a path like string (e.g. "a.java.pkg" is converted to "a/java/pkg"). Hereby
      * always slashes ("/") are used and not the system file separator.
-     * 
+     *
      * @param packageName the package name to convert
      * @return the converted package name as path represention
      */
@@ -112,9 +125,9 @@ public final class ResourceUtil {
      * for all elements of java.class.path get a Collection of resources. All ressources can be found with:
      * <p>
      * <code>
-     * Pattern pattern = Pattern.compile(".*"); 
+     * Pattern pattern = Pattern.compile(".*");
      * </code>
-     * 
+     *
      * @param pattern the pattern to match
      * @return the resources in the order they are found
      */


### PR DESCRIPTION
Sometimes it can be handy to use "." or ".." in paths to model files or even as repdata/resdata offsets or prefixes. 
This works fine for models stored as local files in the file system, but fails for models from ZIP and JAR files. This patch adds a function to canonicalize/resolve path names before looking them up within a ZIP or JAR archives.