### PR TITLE
Support BENDs in FullResponseMatrixTool (for Aloha)

### DIFF
--- a/src/java/cern/accsoft/steering/jmad/kernel/cmd/EfcompCommand.java
+++ b/src/java/cern/accsoft/steering/jmad/kernel/cmd/EfcompCommand.java
@@ -1,0 +1,147 @@
+// @formatter:off
+ /*******************************************************************************
+ *
+ * This file is part of JMad.
+ * 
+ * Copyright (c) 2008-2011, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ******************************************************************************/
+// @formatter:on
+
+/*
+ * $Id: EalignCommand.java,v 1.1 2009-01-15 11:46:26 kfuchsbe Exp $
+ * 
+ * $Date: 2009-01-15 11:46:26 $ $Revision: 1.1 $ $Author: kfuchsbe $
+ * 
+ * Copyright CERN, All Rights Reserved.
+ */
+package cern.accsoft.steering.jmad.kernel.cmd;
+
+import cern.accsoft.steering.jmad.kernel.cmd.param.GenericParameter;
+import cern.accsoft.steering.jmad.kernel.cmd.param.Parameter;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * represents the command for adding magnetic field errors to one or more elements. The elements have to be selected
+ * before by the select command.
+ *
+ * EFCOMP, ORDER=integer, RADIUS=real,
+ *   DKN={dkn(0),  dkn(1),  dkn(2),...},
+ *   DKS={dks(0),  dks(1),  dks(2),...},
+ *   DKNR={dknr(0), dknr(1), dknr(2),...},
+ *   DKSR={dksr(0), dksr(1), dksr(2),...};
+ *
+ * @author michi
+ */
+public class EfcompCommand extends AbstractCommand {
+
+    /** the name of the command */
+    private static final String CMD_NAME = "efcomp";
+
+    private Double radius = null;
+    private Integer order = null;
+    private List<Double> absoluteErrors = null;
+    private List<Double> absoluteSkewErrors = null;
+    private List<Double> relativeErrors = null;
+    private List<Double> relativeSkewErrors = null;
+
+    /**
+     * The default constructor.
+     */
+    public EfcompCommand() {
+    }
+
+    public Double getRadius() {
+        return radius;
+    }
+
+    public void setRadius(Double radius) {
+        this.radius = radius;
+    }
+
+    public Integer getOrder() {
+        return order;
+    }
+
+    public void setOrder(Integer order) {
+        this.order = order;
+    }
+
+    public List<Double> getAbsoluteErrors() {
+        return absoluteErrors;
+    }
+
+    public void setAbsoluteErrors(List<Double> absoluteErrors) {
+        this.absoluteErrors = Optional.ofNullable(absoluteErrors).map(ImmutableList::copyOf).orElse(null);
+    }
+
+    public List<Double> getAbsoluteSkewErrors() {
+        return absoluteSkewErrors;
+    }
+
+    public void setAbsoluteSkewErrors(List<Double> absoluteSkewErrors) {
+        this.absoluteSkewErrors = Optional.ofNullable(absoluteSkewErrors).map(ImmutableList::copyOf).orElse(null);
+    }
+
+    public List<Double> getRelativeErrors() {
+        return relativeErrors;
+    }
+
+    public void setRelativeErrors(List<Double> relativeErrors) {
+        this.relativeErrors = Optional.ofNullable(relativeErrors).map(ImmutableList::copyOf).orElse(null);
+    }
+
+    public List<Double> getRelativeSkewErrors() {
+        return relativeSkewErrors;
+    }
+
+    public void setRelativeSkewErrors(List<Double> relativeSkewErrors) {
+        this.relativeSkewErrors = Optional.ofNullable(relativeSkewErrors).map(ImmutableList::copyOf).orElse(null);
+    }
+
+    @Override
+    public String getName() {
+        return CMD_NAME;
+    }
+
+    @Override
+    public List<Parameter> getParameters() {
+        ArrayList<Parameter> parameters = new ArrayList<Parameter>();
+
+        /*
+         * define the mapping of the member-vars to the parameter names
+         */
+
+        /*
+         * EFCOMP, ORDER=integer, RADIUS=real,
+         *   DKN={dkn(0),  dkn(1),  dkn(2),...},
+         *   DKS={dks(0),  dks(1),  dks(2),...},
+         *   DKNR={dknr(0), dknr(1), dknr(2),...},
+         *   DKSR={dksr(0), dksr(1), dksr(2),...};
+         */
+        parameters.add(new GenericParameter<>("order", order));
+        parameters.add(new GenericParameter<>("radius", radius));
+        parameters.add(new GenericParameter<>("dkn", absoluteErrors));
+        parameters.add(new GenericParameter<>("dks", absoluteSkewErrors));
+        parameters.add(new GenericParameter<>("dknr", relativeErrors));
+        parameters.add(new GenericParameter<>("dksr", relativeSkewErrors));
+        return parameters;
+    }
+
+}

--- a/src/java/cern/accsoft/steering/jmad/kernel/cmd/SelectCommand.java
+++ b/src/java/cern/accsoft/steering/jmad/kernel/cmd/SelectCommand.java
@@ -22,13 +22,18 @@
 
 package cern.accsoft.steering.jmad.kernel.cmd;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import cern.accsoft.steering.jmad.kernel.cmd.param.GenericParameter;
 import cern.accsoft.steering.jmad.kernel.cmd.param.Parameter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class SelectCommand extends AbstractCommand {
+
+    /** the flag to use for the select command to select the twiss output */
+    public static final String SELECT_FLAG_TWISS = "twiss";
+    /** the flag to use for the select command to set the misalignment */
+    public static final String SELECT_FLAG_ERROR = "error";
 
     private static final String CMD_NAME = "select";
 

--- a/src/java/cern/accsoft/steering/jmad/kernel/cmd/param/GenericParameter.java
+++ b/src/java/cern/accsoft/steering/jmad/kernel/cmd/param/GenericParameter.java
@@ -24,6 +24,10 @@ package cern.accsoft.steering.jmad.kernel.cmd.param;
 
 import cern.accsoft.steering.jmad.domain.types.MadxValue;
 
+import java.util.Collection;
+
+import static java.util.stream.Collectors.joining;
+
 public class GenericParameter<T> extends AbstractParameter {
     private String name;
     private T value;
@@ -54,23 +58,30 @@ public class GenericParameter<T> extends AbstractParameter {
 
     @Override
     public String compose() {
-        String valueString;
-
         if (value.getClass().equals(Boolean.class)) {
             if ((Boolean) value) {
                 return name;
             } else {
                 return "";
             }
-        } else if (value instanceof MadxValue) {
-            return name + "=" + ((MadxValue) value).getMadxString();
+        } else if (value instanceof Collection) {
+            Collection<?> values = (Collection<?>) value;
+            return name + "=" + values.stream().map(v -> valueToString(v, useValueQuotes))
+                    .collect(joining(", ", "{", "}"));
+        } else {
+            return name + "=" + valueToString(value, useValueQuotes);
+        }
+    }
+
+    private static String valueToString(Object value, boolean useValueQuotes) {
+        if (value instanceof MadxValue) {
+            return ((MadxValue) value).getMadxString();
         } else {
             if (useValueQuotes) {
-                valueString = "\"" + value.toString() + "\"";
+                return "\"" + value.toString() + "\"";
             } else {
-                valueString = value.toString();
+                return value.toString();
             }
-            return name + "=" + valueString;
         }
     }
 

--- a/src/java/cern/accsoft/steering/jmad/kernel/task/AddFieldErrors.java
+++ b/src/java/cern/accsoft/steering/jmad/kernel/task/AddFieldErrors.java
@@ -10,6 +10,10 @@ import java.util.List;
 
 import static cern.accsoft.steering.jmad.kernel.cmd.SelectCommand.SELECT_FLAG_ERROR;
 
+/**
+ * Task to add absolute field errors to a single element. The provided field errors are ADDED to any field errors
+ * already present by the means of an "eoption,add=true" MAD-X command.
+ */
 public class AddFieldErrors extends AbstractTask {
 
     private final String elementName;

--- a/src/java/cern/accsoft/steering/jmad/kernel/task/AddFieldErrors.java
+++ b/src/java/cern/accsoft/steering/jmad/kernel/task/AddFieldErrors.java
@@ -1,0 +1,61 @@
+package cern.accsoft.steering.jmad.kernel.task;
+
+import cern.accsoft.steering.jmad.kernel.cmd.Command;
+import cern.accsoft.steering.jmad.kernel.cmd.EOptionCommand;
+import cern.accsoft.steering.jmad.kernel.cmd.EfcompCommand;
+import cern.accsoft.steering.jmad.kernel.cmd.SelectCommand;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static cern.accsoft.steering.jmad.kernel.cmd.SelectCommand.SELECT_FLAG_ERROR;
+
+public class AddFieldErrors extends AbstractTask {
+
+    private final String elementName;
+    private final List<Double> absoluteErrors;
+    private final List<Double> absoluteSkewErrors;
+
+    public AddFieldErrors(String element, List<Double> absoluteErrors) {
+        this.elementName = element;
+        this.absoluteErrors = ImmutableList.copyOf(absoluteErrors);
+        absoluteSkewErrors = null;
+    }
+
+    public AddFieldErrors(String element, List<Double> absoluteErrors, List<Double> absoluteSkewErrors) {
+        this.elementName = element;
+        this.absoluteErrors = ImmutableList.copyOf(absoluteErrors);
+        this.absoluteSkewErrors = ImmutableList.copyOf(absoluteSkewErrors);
+    }
+
+    @Override
+    protected List<Command> getCommands() {
+        return ImmutableList.of(
+                new EOptionCommand(null, true),
+                clearErrorSelect(),
+                selectErrorElement(elementName),
+                efcomp()
+        );
+    }
+
+    private static SelectCommand clearErrorSelect() {
+        SelectCommand select = new SelectCommand();
+        select.setFlag(SELECT_FLAG_ERROR);
+        select.setClear(true);
+        return select;
+    }
+
+    private static SelectCommand selectErrorElement(String elementName) {
+        SelectCommand select = new SelectCommand();
+        select.setFlag(SELECT_FLAG_ERROR);
+        select.setPattern(elementName);
+        return select;
+    }
+
+    private EfcompCommand efcomp() {
+        EfcompCommand efcomp = new EfcompCommand();
+        efcomp.setAbsoluteErrors(absoluteErrors);
+        efcomp.setAbsoluteSkewErrors(absoluteSkewErrors);
+        return efcomp;
+    }
+}

--- a/src/java/cern/accsoft/steering/jmad/kernel/task/GetMisalignmentsTask.java
+++ b/src/java/cern/accsoft/steering/jmad/kernel/task/GetMisalignmentsTask.java
@@ -4,13 +4,15 @@
 
 package cern.accsoft.steering.jmad.kernel.task;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import cern.accsoft.steering.jmad.domain.result.ResultType;
 import cern.accsoft.steering.jmad.kernel.cmd.Command;
 import cern.accsoft.steering.jmad.kernel.cmd.EsaveCommand;
 import cern.accsoft.steering.jmad.kernel.cmd.SelectCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static cern.accsoft.steering.jmad.kernel.cmd.SelectCommand.SELECT_FLAG_ERROR;
 
 /**
  * This task is intended to call kernel in order to get actual machine imperfections.
@@ -19,7 +21,6 @@ import cern.accsoft.steering.jmad.kernel.cmd.SelectCommand;
  */
 public class GetMisalignmentsTask extends AbstractTask {
 
-    private static final String ERROR_FLAG = "ERROR";
     private static final String ALL_ELEMENTS_PATTERN = "";
     private final String patternToSelect;
 
@@ -38,8 +39,8 @@ public class GetMisalignmentsTask extends AbstractTask {
     protected List<Command> getCommands() {
 
         SelectCommand selectCommand = new SelectCommand();
-        selectCommand.setFlag(ERROR_FLAG);
-        if (patternToSelect != ALL_ELEMENTS_PATTERN) {
+        selectCommand.setFlag(SELECT_FLAG_ERROR);
+        if (!ALL_ELEMENTS_PATTERN.equals(patternToSelect)) {
             selectCommand.setPattern(patternToSelect);
         } else {
             selectCommand.setFull(true);

--- a/src/java/cern/accsoft/steering/jmad/kernel/task/RunTwiss.java
+++ b/src/java/cern/accsoft/steering/jmad/kernel/task/RunTwiss.java
@@ -22,18 +22,18 @@
 
 package cern.accsoft.steering.jmad.kernel.task;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import cern.accsoft.steering.jmad.domain.result.tfs.TfsResultRequest;
 import cern.accsoft.steering.jmad.domain.twiss.TwissInitialConditions;
 import cern.accsoft.steering.jmad.kernel.cmd.Command;
 import cern.accsoft.steering.jmad.kernel.cmd.DeleteCommand;
 import cern.accsoft.steering.jmad.kernel.cmd.TwissCommand;
 
-public class RunTwiss extends AbstractResultSelectableTask {
+import java.util.ArrayList;
+import java.util.List;
 
-    private static final String SELECT_FLAG_TWISS = "twiss";
+import static cern.accsoft.steering.jmad.kernel.cmd.SelectCommand.SELECT_FLAG_TWISS;
+
+public class RunTwiss extends AbstractResultSelectableTask {
 
     private TwissInitialConditions twiss = null;
 

--- a/src/java/cern/accsoft/steering/jmad/kernel/task/SetMisalignment.java
+++ b/src/java/cern/accsoft/steering/jmad/kernel/task/SetMisalignment.java
@@ -29,14 +29,16 @@
  */
 package cern.accsoft.steering.jmad.kernel.task;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import cern.accsoft.steering.jmad.domain.misalign.Misalignment;
 import cern.accsoft.steering.jmad.domain.misalign.MisalignmentConfiguration;
 import cern.accsoft.steering.jmad.kernel.cmd.Command;
 import cern.accsoft.steering.jmad.kernel.cmd.EalignCommand;
 import cern.accsoft.steering.jmad.kernel.cmd.SelectCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static cern.accsoft.steering.jmad.kernel.cmd.SelectCommand.SELECT_FLAG_ERROR;
 
 /**
  * This class represents a task, which applies a certain misalignment to a element.
@@ -44,9 +46,6 @@ import cern.accsoft.steering.jmad.kernel.cmd.SelectCommand;
  * @author Kajetan Fuchsberger (kajetan.fuchsberger at cern.ch)
  */
 public class SetMisalignment extends AbstractTask {
-
-    /** the flag to use for the select command to set the misalignment */
-    private static final String SELECT_FLAG_ERROR = "error";
 
     /** the machine-element to which to apply the misalignment */
     private final String elementName;

--- a/src/java/cern/accsoft/steering/jmad/tools/response/FullResponseMatrixTool.java
+++ b/src/java/cern/accsoft/steering/jmad/tools/response/FullResponseMatrixTool.java
@@ -211,7 +211,7 @@ public class FullResponseMatrixTool implements ResponseMatrixTool {
         } else if (JMadElementType.BEND.isTypeOf(element)) {
             int tiltSign = bendFieldErrorSignFromTilt(element, plane);
             AddFieldErrors fieldErrorsTask = new AddFieldErrors(element.getName(),
-                    singletonList(kick * tiltSign));
+                    singletonList(kick * tiltSign)); /* this will ADD to any existing field errors */
             model.execute(fieldErrorsTask.compose());
         } else {
             throw new JMadModelException("Element '" + element.getName()

--- a/src/java/cern/accsoft/steering/jmad/tools/response/ResponseMatrixTool.java
+++ b/src/java/cern/accsoft/steering/jmad/tools/response/ResponseMatrixTool.java
@@ -20,9 +20,6 @@
  ******************************************************************************/
 // @formatter:on
 
-/**
- * 
- */
 package cern.accsoft.steering.jmad.tools.response;
 
 import Jama.Matrix;
@@ -45,6 +42,6 @@ public interface ResponseMatrixTool {
      * @return the response-matrix
      * @throws JMadModelException if the calculation of the response matrix fails
      */
-    public abstract Matrix calcResponseMatrix(JMadModel model, ResponseRequest request) throws JMadModelException;
+    Matrix calcResponseMatrix(JMadModel model, ResponseRequest request) throws JMadModelException;
 
 }

--- a/src/test/cern/accsoft/steering/jmad/tools/response/ResponseMatrixToolTest.java
+++ b/src/test/cern/accsoft/steering/jmad/tools/response/ResponseMatrixToolTest.java
@@ -22,19 +22,18 @@
 
 package cern.accsoft.steering.jmad.tools.response;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import Jama.Matrix;
 import cern.accsoft.steering.jmad.JMadTestCase;
 import cern.accsoft.steering.jmad.domain.ex.JMadModelException;
 import cern.accsoft.steering.jmad.domain.types.enums.JMadPlane;
 import cern.accsoft.steering.jmad.model.JMadModel;
 import cern.accsoft.steering.jmad.modeldefs.domain.JMadModelDefinition;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ResponseMatrixToolTest extends JMadTestCase {
 
@@ -64,7 +63,8 @@ public class ResponseMatrixToolTest extends JMadTestCase {
 
         ResponseRequestImpl request = new ResponseRequestImpl();
         request.addCorrector("MCIAV.20304", 0.5e-4, JMadPlane.V);
-        request.addCorrector("MCIAV.20504", 0.5e-4, JMadPlane.V);
+//        request.addCorrector("MCIAV.20504", 0.5e-4, JMadPlane.V);
+        request.addCorrector("MDLV.610304.BEND", 0.5e-4, JMadPlane.V);
         request.addMonitor("BPMIH.20204", JMadPlane.H);
         request.addMonitor("BPMIH.20404", JMadPlane.H);
         request.addMonitor("BPMIV.20504", JMadPlane.V);
@@ -74,19 +74,17 @@ public class ResponseMatrixToolTest extends JMadTestCase {
         assertEquals("Matrix should be 3x2", 3, responseMatrix.getRowDimension());
 
         // these pickups are before the kickers ;-) -> no results
-        assertEquals(0.0, responseMatrix.get(0, 0), 0.00000000000001);
-        assertEquals(0.0, responseMatrix.get(0, 1), 0.00000000000001);
-        assertEquals(0.0, responseMatrix.get(1, 1), 0.00000000000001);
+        assertEquals(0.0, responseMatrix.get(0, 0), 1e-4);
         // x-pickup, y-kick -> no result
-        assertEquals(0.0, responseMatrix.get(1, 0), 0.00000000000001);
+        assertEquals(0.0, responseMatrix.get(1, 0), 1e-4);
+        assertEquals(0.0, responseMatrix.get(0, 1), 1e-4);
+        assertEquals(0.0, responseMatrix.get(1, 1), 1e-4);
 
         // these pickups should return values:
-        // strength ACIBV.20304, monitor BPMIV.20504,
         // TODO: rechecked manually with madx!
-        assertEquals(90.86729324, responseMatrix.get(2, 0), 0.00000001);
+        assertEquals(90.86729324, responseMatrix.get(2, 0), 1e-4);
+        assertEquals(141.2689035, responseMatrix.get(2, 1), 1e-4);
 
-        // BPMIV.20504 again seems to be before RCIBV.20504 -> no result.
-        assertEquals(0.0, responseMatrix.get(2, 1), 0.00000000001);
     }
 
 }


### PR DESCRIPTION
This change set adds basic support for defining field errors (using a new AddFieldErrors task). It uses this functionality to support kicks from BENDs in FullResponseMatrixTool (which is used by Aloha).

In the end, this will add support for BEND-based Kick-Response measurements to Aloha.